### PR TITLE
feat: add github workflow skills

### DIFF
--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: github-pr-workflow
+description: "GitHub PR lifecycle: branch, commit, open, CI, merge."
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [GitHub, Pull-Requests, CI/CD, Git, Automation, Merge]
+    related_skills: [github-auth, github-repo-management, github-code-review]
+---
+
+# GitHub Pull Request Workflow
+
+Complete guide for managing the PR lifecycle. Each section shows the `gh` way first, then the `git` + `curl` fallback for machines without `gh`.
+
+This skill assumes the repository is already cloned and the branch/worktree context is known. For repo setup, cloning, remotes, and branch/worktree housekeeping, use the Git-focused workflow in `github-repo-management`.
+
+## Prerequisites
+
+- Authenticated with GitHub (see `github-auth` skill)
+- Inside a git repository with a GitHub remote
+- For cloning, remotes, and worktree setup, see `github-repo-management`
+
+### Quick Auth Detection
+
+```bash
+# Determine which method to use throughout this workflow
+if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+  AUTH="gh"
+else
+  AUTH="git"
+  # Ensure we have a token for API calls
+  if [ -z "$GITHUB_TOKEN" ]; then
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
+      GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
+    fi
+  fi
+fi
+echo "Using: $AUTH"
+```
+
+### Extracting Owner/Repo from the Git Remote
+
+Many `curl` commands need `owner/repo`. Extract it from the git remote:
+
+```bash
+# Works for both HTTPS and SSH remote URLs
+REMOTE_URL=$(git remote get-url origin)
+OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
+REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+echo "Owner: $OWNER, Repo: $REPO"
+```
+
+---
+
+## 1. Branch Creation
+
+This part is pure `git` — identical either way:
+
+```bash
+# Make sure you're up to date
+git fetch origin
+git checkout main && git pull origin main
+
+# Create and switch to a new branch
+git checkout -b feat/add-user-authentication
+```
+
+Branch naming conventions:
+- `feat/description` — new features
+- `fix/description` — bug fixes
+- `refactor/description` — code restructuring
+- `docs/description` — documentation
+- `ci/description` — CI/CD changes
+
+## 2. Making Commits
+
+Use the agent's file tools (`write_file`, `patch`) to make changes, then commit:
+
+```bash
+# Stage specific files
+git add src/auth.py src/models/user.py tests/test_auth.py
+
+# Commit with a conventional commit message
+git commit -m "feat: add JWT-based user authentication
+
+- Add login/register endpoints
+- Add User model with password hashing
+- Add auth middleware for protected routes
+- Add unit tests for auth flow"
+```
+
+Commit message format (Conventional Commits):
+```
+type(scope): short description
+
+Longer explanation if needed. Wrap at 72 characters.
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
+
+## 3. Pushing and Creating a PR
+
+### PR body reset rule
+
+When the user asks to "adjust the PR body" or "start over from the beginning," do **not** try to incrementally patch the old body in place.
+
+Instead:
+1. Read the current PR body only as context.
+2. Rewrite the entire body from scratch with a clean structure.
+3. Use a temporary file plus `--body-file` when editing with `gh pr edit` to avoid shell-quoting problems from backticks, Markdown, and code fences.
+4. Re-fetch the PR body afterward to confirm the update landed exactly as intended.
+5. If a PR body is likely to contain code, backticks, or long Markdown sections, default to the file-based path even when inline editing would fit.
+
+See `references/pr-body-reset.md` for the reusable command pattern.
+
+This avoids drift, stale wording, and accidental shell parsing errors.
+
+### Repo targeting rule
+
+When `gh` appears to be pointing at the wrong repository context, do not assume the current checkout is enough.
+
+- Verify the intended repo with `gh repo view -R <owner>/<repo>` or by checking the remote explicitly.
+- Pass `-R <owner>/<repo>` to `gh pr create`, `gh pr edit`, `gh pr view`, and similar commands when the repo context is ambiguous or a sibling repo/default branch is involved.
+- Treat "No commits between main and <branch>" or a surprising default repo name as a signal to re-run the command with an explicit repo target.
+- For broader repository operations such as cloning, remote setup, branch/worktree management, or moving between checkouts, prefer `github-repo-management`.
+
+### Multi-PR / multi-repo safety harness
+
+When the session contains more than one active PR or more than one repository, the default failure mode is to act on the wrong target. Make the target explicit before every mutation.
+
+- Before creating, editing, merging, or commenting on a PR, restate the exact target as `owner/repo#number` or the full PR URL in your own working notes.
+- Re-read the target with `gh pr view -R <owner/repo> <number>` immediately before mutation.
+- After mutation, re-fetch the same PR and confirm the URL, repo, branch, and body match the intended target.
+- Never reuse a PR number from another repository without an explicit `-R` flag.
+- If the user says "fix the dotfiles PR" or names a repository, treat that repository as the only valid target until the task is complete.
+
+### Push the Branch (same either way)
+
+```bash
+git push -u origin HEAD
+```
+
+### Create the PR
+
+If `gh pr create` reports missing head/base SHAs or says there are no commits, or if gh seems to resolve the wrong repository, specify the repository and head branch explicitly. See `references/gh-pr-create-troubleshooting.md`.
+
+**With gh:**
+
+```bash
+gh pr create \
+  --title "feat: add JWT-based user authentication" \
+  --body "## Summary
+- Adds login and register API endpoints
+- JWT token generation and validation
+
+## Test Plan
+- [ ] Unit tests pass
+
+Closes #42"
+```
+
+Options: `--draft`, `--reviewer user1,user2`, `--label "enhancement"`, `--base develop`
+
+**With git + curl:**
+
+```bash
+BRANCH=$(git branch --show-current)
+
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.v3+json" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls \
+  -d "{
+    \"title\": \"feat: add JWT-based user authentication\",
+    \"body\": \"## Summary\nAdds login and register API endpoints.\n\nCloses #42\",
+    \"head\": \"$BRANCH\",
+    \"base\": \"main\"
+  }"
+```
+
+The response JSON includes the PR `number` — save it for later commands.
+
+To create as a draft, add `"draft": true` to the JSON body.
+
+## 4. Monitoring CI Status
+
+### Check CI Status
+
+**With gh:**
+
+```bash
+# One-shot check
+gh pr checks
+
+# Watch until all checks finish (polls every 10s)
+gh pr checks --watch
+```
+
+**With git + curl:**
+
+```bash
+# Get the latest commit SHA on the current branch
+SHA=$(git rev-parse HEAD)
+
+# Query the combined status
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/status \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+print(f\"Overall: {data['state']}\")
+for s in data.get('statuses', []):
+    print(f\"  {s['context']}: {s['state']} - {s.get('description', '')}\")"
+
+# Also check GitHub Actions check runs (separate endpoint)
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/check-runs \
+  | python3 -c "
+import sys, json
+data = json.load(sys.stdin)
+for cr in data.get('check_runs', []):
+    print(f\"  {cr['name']}: {cr['status']} / {cr['conclusion'] or 'pending'}\")"
+```
+
+### Poll Until Complete (git + curl)
+
+```bash
+# Simple polling loop — check every 30 seconds, up to 10 minutes
+SHA=$(git rev-parse HEAD)
+for i in $(seq 1 20); do
+  STATUS=$(curl -s \
+    -H "Authorization: token $GITHUB_TOKEN" \
+    https://api.github.com/repos/$OWNER/$REPO/commits/$SHA/status \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['state'])")
+  echo "Check $i: $STATUS"
+  if [ "$STATUS" = "success" ] || [ "$STATUS" = "failure" ] || [ "$STATUS" = "error" ]; then
+    break
+  fi
+  sleep 30
+done
+```
+
+## 5. Auto-Fixing CI Failures
+
+When CI fails, diagnose and fix. This loop works with either auth method.
+
+### Step 1: Get Failure Details
+
+**With gh:**
+
+```bash
+# List recent workflow runs on this branch
+gh run list --branch $(git branch --show-current) --limit 5
+
+# View failed logs
+gh run view <RUN_ID> --log-failed
+```
+
+**With git + curl:**
+
+```bash
+BRANCH=$(git branch --show-current)
+
+# List workflow runs on this branch
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/actions/runs?branch=$BRANCH&per_page=5" \
+  | python3 -c "
+import sys, json
+runs = json.load(sys.stdin)['workflow_runs']
+for r in runs:
+    print(f\"Run {r['id']}: {r['name']} - {r['conclusion'] or r['status']}\")"
+
+# Get failed job logs (download as zip, extract, read)
+RUN_ID=<run_id>
+curl -s -L \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/runs/$RUN_ID/logs \
+  -o /tmp/ci-logs.zip
+cd /tmp && unzip -o ci-logs.zip -d ci-logs && cat ci-logs/*.txt
+```
+
+### Step 2: Fix and Push
+
+After identifying the issue, use file tools (`patch`, `write_file`) to fix it:
+
+```bash
+git add <fixed_files>
+git commit -m "fix: resolve CI failure in <check_name>"
+git push
+```
+
+### Step 3: Verify
+
+Re-check CI status using the commands from Section 4 above.
+
+### Auto-Fix Loop Pattern
+
+When asked to auto-fix CI, follow this loop:
+
+1. Check CI status → identify failures
+2. Read failure logs → understand the error
+3. Use `read_file` + `patch`/`write_file` → fix the code
+4. `git add . && git commit -m "fix: ..." && git push`
+5. Wait for CI → re-check status
+6. Repeat if still failing (up to 3 attempts, then ask the user)
+
+## 6. Merging
+
+**With gh:**
+
+```bash
+# Squash merge + delete branch (cleanest for feature branches)
+gh pr merge --squash --delete-branch
+
+# Enable auto-merge (merges when all checks pass)
+gh pr merge --auto --squash --delete-branch
+```
+
+**With git + curl:**
+
+```bash
+PR_NUMBER=<number>
+
+# Merge the PR via API (squash)
+curl -s -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/merge \
+  -d "{
+    \"merge_method\": \"squash\",
+    \"commit_title\": \"feat: add user authentication (#$PR_NUMBER)\"
+  }"
+
+# Delete the remote branch after merge
+BRANCH=$(git branch --show-current)
+git push origin --delete $BRANCH
+
+# Switch back to main locally
+git checkout main && git pull origin main
+git branch -d $BRANCH
+```
+
+Merge methods: `"merge"`, `"squash"`, `"rebase"`
+
+### Enable Auto-Merge (curl)
+
+```bash
+# Auto-merge requires the repo to have it enabled in settings.
+# This uses the GraphQL API since REST doesn't support auto-merge.
+PR_NODE_ID=$(curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
+  | python3 -c "import sys,json; print(json.load(sys.stdin)['node_id'])")
+
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/graphql \
+  -d "{\"query\": \"mutation { enablePullRequestAutoMerge(input: {pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH}) { clientMutationId } }\"}"
+```
+
+## 7. Complete Workflow Example
+
+```bash
+# 1. Start from clean main
+git checkout main && git pull origin main
+
+# 2. Branch
+git checkout -b fix/login-redirect-bug
+
+# 3. (Agent makes code changes with file tools)
+
+# 4. Commit
+git add src/auth/login.py tests/test_login.py
+git commit -m "fix: correct redirect URL after login
+
+Preserves the ?next= parameter instead of always redirecting to /dashboard."
+
+# 5. Push
+git push -u origin HEAD
+
+# 6. Create PR (picks gh or curl based on what's available)
+# ... (see Section 3)
+
+# 7. Monitor CI (see Section 4)
+
+# 8. Merge when green (see Section 6)
+```
+
+## Scheduled PR Maintenance / Conflict-Rebase Automation
+
+When setting up recurring automation for PR maintenance (for example, nightly checks that rebase conflicting PR branches), bake the safety constraints into the cron prompt instead of relying on implicit judgment:
+
+1. Scope PR discovery narrowly: list only open PRs by the intended author (for this user, `author:koh110`) and only act on PRs whose merge state clearly indicates conflicts (for GitHub, `mergeStateStatus` such as `DIRTY`; follow up on `UNKNOWN` before acting).
+2. Confirm `gh auth status` and git availability at the start of each run.
+3. Only modify head branches where the authenticated user has push rights. Never push to, rebase, or merge the base branch.
+4. If rewriting history, use `git push --force-with-lease` and only to the PR head branch.
+5. If a conflict cannot be resolved confidently, or auth/permissions/test setup are unexpected, stop for that PR, leave a concise PR comment, and include the reason in the final cron report.
+6. For this user's development tasks, clone repositories under `~/dev`; put working caches and temporary checkouts under `~/dev/tmp` (for example `~/dev/tmp/_hermes_pr_rebase_cache`). For parallel development, create a `.worktree/` directory at the repository root and create isolated working directories inside it with `git worktree` (for example `git worktree add .worktree/<task-branch> -b <task-branch> origin/main`), then do implementation work from that worktree rather than the main checkout.
+7. Cron jobs should report: checked PR count, conflict target count, successful PR URLs + verification, skipped/failed PR URLs + reasons, and important error excerpts.
+
+## Useful PR Commands Reference
+
+| Action | gh | git + curl |
+|--------|-----|-----------|
+| List my PRs | `gh pr list --author @me` | `curl -s -H "Authorization: token $GITHUB_TOKEN" "https://api.github.com/repos/$OWNER/$REPO/pulls?state=open"` |
+| View PR diff | `gh pr diff` | `git diff main...HEAD` (local) or `curl -H "Accept: application/vnd.github.diff" ...` |
+| Add comment | `gh pr comment N --body "..."` | `curl -X POST .../issues/N/comments -d '{"body":"..."}'` |
+| Request review | `gh pr edit N --add-reviewer user` | `curl -X POST .../pulls/N/requested_reviewers -d '{"reviewers":["user"]}'` |
+| Close PR | `gh pr close N` | `curl -X PATCH .../pulls/N -d '{"state":"closed"}'` |
+| Check out someone's PR | `gh pr checkout N` | `git fetch origin pull/N/head:pr-N && git checkout pr-N` |

--- a/skills/github/github-repo-management/SKILL.md
+++ b/skills/github/github-repo-management/SKILL.md
@@ -1,0 +1,539 @@
+---
+name: github-repo-management
+description: "Clone/create/fork repos; manage remotes, releases."
+version: 1.1.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [GitHub, Repositories, Git, Releases, Secrets, Configuration]
+    related_skills: [github-auth, github-pr-workflow, github-issues]
+---
+
+# GitHub Repository Management
+
+Create, clone, fork, configure, and manage GitHub repositories. Each section shows `gh` first, then the `git` + `curl` fallback.
+
+## Prerequisites
+
+- Authenticated with GitHub (see `github-auth` skill)
+
+### Setup
+
+```bash
+if command -v gh &>/dev/null && gh auth status &>/dev/null; then
+  AUTH="gh"
+else
+  AUTH="git"
+  if [ -z "$GITHUB_TOKEN" ]; then
+    if _hermes_env="${HERMES_HOME:-$HOME/.hermes}/.env"; [ -f "$_hermes_env" ] && grep -q "^GITHUB_TOKEN=" "$_hermes_env"; then
+      GITHUB_TOKEN=$(grep "^GITHUB_TOKEN=" "$_hermes_env" | head -1 | cut -d= -f2 | tr -d '\n\r')
+    elif grep -q "github.com" ~/.git-credentials 2>/dev/null; then
+      GITHUB_TOKEN=$(grep "github.com" ~/.git-credentials 2>/dev/null | head -1 | sed 's|https://[^:]*:\([^@]*\)@.*|\1|')
+    fi
+  fi
+fi
+
+# Get your GitHub username (needed for several operations)
+if [ "$AUTH" = "gh" ]; then
+  GH_USER=$(gh api user --jq '.login')
+else
+  GH_USER=$(curl -s -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/user | python3 -c "import sys,json; print(json.load(sys.stdin)['login'])")
+fi
+```
+
+If you're inside a repo already:
+
+```bash
+REMOTE_URL=$(git remote get-url origin)
+OWNER_REPO=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+OWNER=$(echo "$OWNER_REPO" | cut -d/ -f1)
+REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
+```
+
+---
+
+## 1. Cloning Repositories
+
+Cloning is pure `git` — works identically either way:
+
+```bash
+# Clone via HTTPS (works with credential helper or token-embedded URL)
+git clone https://github.com/owner/repo-name.git
+
+# Clone into a specific directory
+git clone https://github.com/owner/repo-name.git ./my-local-dir
+
+# Shallow clone (faster for large repos)
+git clone --depth 1 https://github.com/owner/repo-name.git
+
+# Clone a specific branch
+git clone --branch develop https://github.com/owner/repo-name.git
+
+# Clone via SSH (if SSH is configured)
+git clone git@github.com:owner/repo-name.git
+```
+
+**With gh (shorthand):**
+
+```bash
+gh repo clone owner/repo-name
+gh repo clone owner/repo-name -- --depth 1
+```
+
+**Private repo fallback when `gh` is authenticated but SSH clone fails**
+
+If `gh auth status` shows access, but `gh repo clone` tries `git@github.com:...` and fails with `Permission denied (publickey)`, use the gh token as a temporary HTTPS askpass helper. This avoids embedding tokens in remotes or logs:
+
+```bash
+cat > /tmp/gh-askpass.sh <<'SH'
+#!/bin/sh
+case "$1" in
+  *Username*) echo x-access-token ;;
+  *Password*) gh auth token ;;
+  *) echo ;;
+esac
+SH
+chmod 700 /tmp/gh-askpass.sh
+GIT_ASKPASS=/tmp/gh-askpass.sh GIT_TERMINAL_PROMPT=0 \
+  git clone https://github.com/owner/repo-name.git repo-name
+rm -f /tmp/gh-askpass.sh
+cd repo-name
+git remote set-url origin https://github.com/owner/repo-name.git
+```
+
+Use this when the repo is private and the GitHub CLI token has `repo` scope, but local SSH keys are not configured for GitHub.
+
+## 2. Creating Repositories
+
+**With gh:**
+
+```bash
+# Create a public repo and clone it
+gh repo create my-new-project --public --clone
+
+# Private, with description and license
+gh repo create my-new-project --private --description "A useful tool" --license MIT --clone
+
+# Under an organization
+gh repo create my-org/my-new-project --public --clone
+
+# From existing local directory
+cd /path/to/existing/project
+gh repo create my-project --source . --public --push
+```
+
+**With git + curl:**
+
+```bash
+# Create the remote repo via API
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/user/repos \
+  -d '{
+    "name": "my-new-project",
+    "description": "A useful tool",
+    "private": false,
+    "auto_init": true,
+    "license_template": "mit"
+  }'
+
+# Clone it
+git clone https://github.com/$GH_USER/my-new-project.git
+cd my-new-project
+
+# -- OR -- push an existing local directory to the new repo
+cd /path/to/existing/project
+git init
+git add .
+git commit -m "Initial commit"
+git remote add origin https://github.com/$GH_USER/my-new-project.git
+git push -u origin main
+```
+
+To create under an organization:
+
+```bash
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/orgs/my-org/repos \
+  -d '{"name": "my-new-project", "private": false}'
+```
+
+### From a Template
+
+**With gh:**
+
+```bash
+gh repo create my-new-app --template owner/template-repo --public --clone
+```
+
+**With curl:**
+
+```bash
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/owner/template-repo/generate \
+  -d '{"owner": "'"$GH_USER"'", "name": "my-new-app", "private": false}'
+```
+
+## 3. Forking Repositories
+
+**With gh:**
+
+```bash
+gh repo fork owner/repo-name --clone
+```
+
+**With git + curl:**
+
+```bash
+# Create the fork via API
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/owner/repo-name/forks
+
+# Wait a moment for GitHub to create it, then clone
+sleep 3
+git clone https://github.com/$GH_USER/repo-name.git
+cd repo-name
+
+# Add the original repo as "upstream" remote
+git remote add upstream https://github.com/owner/repo-name.git
+```
+
+### Keeping a Fork in Sync
+
+```bash
+# Pure git — works everywhere
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+**With gh (shortcut):**
+
+```bash
+gh repo sync $GH_USER/repo-name
+```
+
+## 4. Repository Information
+
+**With gh:**
+
+```bash
+gh repo view owner/repo-name
+gh repo list --limit 20
+gh search repos "machine learning" --language python --sort stars
+```
+
+**With curl:**
+
+```bash
+# View repo details
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO \
+  | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+print(f\"Name: {r['full_name']}\")
+print(f\"Description: {r['description']}\")
+print(f\"Stars: {r['stargazers_count']}  Forks: {r['forks_count']}\")
+print(f\"Default branch: {r['default_branch']}\")
+print(f\"Language: {r['language']}\")"
+
+# List your repos
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/user/repos?per_page=20&sort=updated" \
+  | python3 -c "
+import sys, json
+for r in json.load(sys.stdin):
+    vis = 'private' if r['private'] else 'public'
+    print(f\"  {r['full_name']:40}  {vis:8}  {r.get('language', ''):10}  ★{r['stargazers_count']}\")"
+
+# Search repos
+curl -s \
+  "https://api.github.com/search/repositories?q=machine+learning+language:python&sort=stars&per_page=10" \
+  | python3 -c "
+import sys, json
+for r in json.load(sys.stdin)['items']:
+    print(f\"  {r['full_name']:40}  ★{r['stargazers_count']:6}  {r['description'][:60] if r['description'] else ''}\")"
+```
+
+## 5. Repository Settings
+
+**With gh:**
+
+```bash
+gh repo edit --description "Updated description" --visibility public
+gh repo edit --enable-wiki=false --enable-issues=true
+gh repo edit --default-branch main
+gh repo edit --add-topic "machine-learning,python"
+gh repo edit --enable-auto-merge
+```
+
+**With curl:**
+
+```bash
+curl -s -X PATCH \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO \
+  -d '{
+    "description": "Updated description",
+    "has_wiki": false,
+    "has_issues": true,
+    "allow_auto_merge": true
+  }'
+
+# Update topics
+curl -s -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Accept: application/vnd.github.mercy-preview+json" \
+  https://api.github.com/repos/$OWNER/$REPO/topics \
+  -d '{"names": ["machine-learning", "python", "automation"]}'
+```
+
+## 6. Branch Protection
+
+```bash
+# View current protection
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/branches/main/protection
+
+# Set up branch protection
+curl -s -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/branches/main/protection \
+  -d '{
+    "required_status_checks": {
+      "strict": true,
+      "contexts": ["ci/test", "ci/lint"]
+    },
+    "enforce_admins": false,
+    "required_pull_request_reviews": {
+      "required_approving_review_count": 1
+    },
+    "restrictions": null
+  }'
+```
+
+## 7. Secrets Management (GitHub Actions)
+
+**With gh:**
+
+```bash
+gh secret set API_KEY --body "your-secret-value"
+gh secret set SSH_KEY < ~/.ssh/id_rsa
+gh secret list
+gh secret delete API_KEY
+```
+
+**With curl:**
+
+Secrets require encryption with the repo's public key — more involved via API:
+
+```bash
+# Get the repo's public key for encrypting secrets
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/secrets/public-key
+
+# Encrypt and set (requires Python with PyNaCl)
+python3 -c "
+from base64 import b64encode
+from nacl import encoding, public
+import json, sys
+
+# Get the public key
+key_id = '<key_id_from_above>'
+public_key = '<base64_key_from_above>'
+
+# Encrypt
+sealed = public.SealedBox(
+    public.PublicKey(public_key.encode('utf-8'), encoding.Base64Encoder)
+).encrypt('your-secret-value'.encode('utf-8'))
+print(json.dumps({
+    'encrypted_value': b64encode(sealed).decode('utf-8'),
+    'key_id': key_id
+}))"
+
+# Then PUT the encrypted secret
+curl -s -X PUT \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/secrets/API_KEY \
+  -d '<output from python script above>'
+
+# List secrets (names only, values hidden)
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/secrets \
+  | python3 -c "
+import sys, json
+for s in json.load(sys.stdin)['secrets']:
+    print(f\"  {s['name']:30}  updated: {s['updated_at']}\")"
+```
+
+Note: For secrets, `gh secret set` is dramatically simpler. If setting secrets is needed and `gh` isn't available, recommend installing it for just that operation.
+
+## 8. Releases
+
+**With gh:**
+
+```bash
+gh release create v1.0.0 --title "v1.0.0" --generate-notes
+gh release create v2.0.0-rc1 --draft --prerelease --generate-notes
+gh release create v1.0.0 ./dist/binary --title "v1.0.0" --notes "Release notes"
+gh release list
+gh release download v1.0.0 --dir ./downloads
+```
+
+**With curl:**
+
+```bash
+# Create a release
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/releases \
+  -d '{
+    "tag_name": "v1.0.0",
+    "name": "v1.0.0",
+    "body": "## Changelog\n- Feature A\n- Bug fix B",
+    "draft": false,
+    "prerelease": false,
+    "generate_release_notes": true
+  }'
+
+# List releases
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/releases \
+  | python3 -c "
+import sys, json
+for r in json.load(sys.stdin):
+    tag = r.get('tag_name', 'no tag')
+    print(f\"  {tag:15}  {r['name']:30}  {'draft' if r['draft'] else 'published'}\")"
+
+# Upload a release asset (binary file)
+RELEASE_ID=<id_from_create_response>
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  -H "Content-Type: application/octet-stream" \
+  "https://uploads.github.com/repos/$OWNER/$REPO/releases/$RELEASE_ID/assets?name=binary-amd64" \
+  --data-binary @./dist/binary-amd64
+```
+
+## 9. GitHub Actions Workflows
+
+**With gh:**
+
+```bash
+gh workflow list
+gh run list --limit 10
+gh run view <RUN_ID>
+gh run view <RUN_ID> --log-failed
+gh run rerun <RUN_ID>
+gh run rerun <RUN_ID> --failed
+gh workflow run ci.yml --ref main
+gh workflow run deploy.yml -f environment=staging
+```
+
+**With curl:**
+
+```bash
+# List workflows
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/workflows \
+  | python3 -c "
+import sys, json
+for w in json.load(sys.stdin)['workflows']:
+    print(f\"  {w['id']:10}  {w['name']:30}  {w['state']}\")"
+
+# List recent runs
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/repos/$OWNER/$REPO/actions/runs?per_page=10" \
+  | python3 -c "
+import sys, json
+for r in json.load(sys.stdin)['workflow_runs']:
+    print(f\"  Run {r['id']}  {r['name']:30}  {r['conclusion'] or r['status']}\")"
+
+# Download failed run logs
+RUN_ID=<run_id>
+curl -s -L \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/runs/$RUN_ID/logs \
+  -o /tmp/ci-logs.zip
+cd /tmp && unzip -o ci-logs.zip -d ci-logs
+
+# Re-run a failed workflow
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/runs/$RUN_ID/rerun
+
+# Re-run only failed jobs
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/runs/$RUN_ID/rerun-failed-jobs
+
+# Trigger a workflow manually (workflow_dispatch)
+WORKFLOW_ID=<workflow_id_or_filename>
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/repos/$OWNER/$REPO/actions/workflows/$WORKFLOW_ID/dispatches \
+  -d '{"ref": "main", "inputs": {"environment": "staging"}}'
+```
+
+## 10. Gists
+
+**With gh:**
+
+```bash
+gh gist create script.py --public --desc "Useful script"
+gh gist list
+```
+
+**With curl:**
+
+```bash
+# Create a gist
+curl -s -X POST \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/gists \
+  -d '{
+    "description": "Useful script",
+    "public": true,
+    "files": {
+      "script.py": {"content": "print(\"hello\")"}
+    }
+  }'
+
+# List your gists
+curl -s \
+  -H "Authorization: token $GITHUB_TOKEN" \
+  https://api.github.com/gists \
+  | python3 -c "
+import sys, json
+for g in json.load(sys.stdin):
+    files = ', '.join(g['files'].keys())
+    print(f\"  {g['id']}  {g['description'] or '(no desc)':40}  {files}\")"
+```
+
+## Quick Reference Table
+
+| Action | gh | git + curl |
+|--------|-----|-----------|
+| Clone | `gh repo clone o/r` | `git clone https://github.com/o/r.git` |
+| Create repo | `gh repo create name --public` | `curl POST /user/repos` |
+| Fork | `gh repo fork o/r --clone` | `curl POST /repos/o/r/forks` + `git clone` |
+| Repo info | `gh repo view o/r` | `curl GET /repos/o/r` |
+| Edit settings | `gh repo edit --...` | `curl PATCH /repos/o/r` |
+| Create release | `gh release create v1.0` | `curl POST /repos/o/r/releases` |
+| List workflows | `gh workflow list` | `curl GET /repos/o/r/actions/workflows` |
+| Rerun CI | `gh run rerun ID` | `curl POST /repos/o/r/actions/runs/ID/rerun` |
+| Set secret | `gh secret set KEY` | `curl PUT /repos/o/r/actions/secrets/KEY` (+ encryption) |


### PR DESCRIPTION
## Summary
- Add reusable backups of the GitHub PR workflow skill and the GitHub repository management skill
- Position both skills as generic GitHub workflows that can also be reused from Codex-style environments

## What changed
- Added `skills/github/github-pr-workflow/SKILL.md`
- Added `skills/github/github-repo-management/SKILL.md`
- Kept the PR workflow focused on PR lifecycle tasks
- Kept the repository-management skill focused on clone/fork/remote/worktree and repository setup

## Verification
- Reviewed both SKILL.md files in the worktree
- Committed and pushed the branch

## Notes
- This PR is intended as a portable backup of the skill pair for other agent stacks as well.
